### PR TITLE
Enhance the disassembler

### DIFF
--- a/src/disasm.c
+++ b/src/disasm.c
@@ -9,41 +9,34 @@
 #define LINES 16
 
 char strDisasm[LEN*LINES+1];
+int showBytes = 0;
 
 void disasmAtAddress(int32_t addr)
 {
+	char line[128];
 	struct thumb_disasm_t dis;
 	int instLen = 0;
 
-	dis.pc = 0x100;
-
-	for(int i=0; i<LINES/2; i++)
+	snprintf (strDisasm, LEN+1, "Page: 0x%x\n", (unsigned int)(addr >> 24));
+	for (int i=1; i<LINES; i++)
 	{
-		char s1[11] = {0};
-		char s2[LEN+1] = {0};
-
+		unsigned int laddr = (unsigned int) (addr & 0xffffff);
 		dis.buf = (const uint8_t*)(addr);
-		
+		dis.pc = addr;
 		instLen = thumb_disasm (&dis);
 
 		APP_LOG(APP_LOG_LEVEL_INFO, "Instruction: %s\n", dis.str);
 
-		if(instLen)
-		{
-			strncpy(s1, dis.str, 10);
-			if(strlen(dis.str) > 10)
-				strncpy(s2, dis.str+10, 23);
-			else
-				strncpy(s2, "", 0);
+		if (showBytes) {
+			if (instLen == 2) {
+				snprintf(line, sizeof(line), "%05x %02x %02x\n", laddr, dis.buf[0], dis.buf[1]);
+			} else if (instLen == 4) {
+				snprintf(line, sizeof(line), "%05x %02x %02x %02x %02x\n", laddr, dis.buf[0], dis.buf[1], dis.buf[2], dis.buf[3]);
+			}
+		} else {
+			snprintf(line, sizeof(line), "%05x %s\n", laddr, dis.str);
 		}
-		else
-		{
-			strncpy(s1, "invalid", 8);
-			strncpy(s2, "", 0);
-		}
-
-		snprintf(strDisasm+i*LEN*2, LEN+1, "%08x(%1d): %10.10s\n", (unsigned int)(addr), instLen, s1);
-		snprintf(strDisasm+i*LEN*2+LEN, LEN+1, "%23.23s\n", s2);
+		strcat (strDisasm, line);
 
 		addr += instLen;
 	}
@@ -55,6 +48,13 @@ void disasm_up(ClickRecognizerRef recognizer, void* context)
 	(void)recognizer;
 	
 	disasmAtAddress(address -= 2);
+	layer_mark_dirty(text_layer_get_layer(disasmW_dis));
+}
+
+void disasm_select(ClickRecognizerRef recognizer, void* context)
+{
+	showBytes = showBytes? 0: 1;
+	disasmAtAddress(address);
 	layer_mark_dirty(text_layer_get_layer(disasmW_dis));
 }
 
@@ -75,8 +75,9 @@ void disasm_down(ClickRecognizerRef recognizer, void* context)
 
 void disasm_click_config_provider(void* context)
 {
-	window_single_repeating_click_subscribe(BUTTON_ID_UP, 100, disasm_up);
-	window_single_repeating_click_subscribe(BUTTON_ID_DOWN, 100, disasm_down);
+	window_single_repeating_click_subscribe(BUTTON_ID_UP, 50, disasm_up);
+	window_single_repeating_click_subscribe(BUTTON_ID_SELECT, 50, disasm_select);
+	window_single_repeating_click_subscribe(BUTTON_ID_DOWN, 50, disasm_down);
 }
 
 void showDisasm()

--- a/src/pebble-disthumb/src/thumb.c
+++ b/src/pebble-disthumb/src/thumb.c
@@ -170,14 +170,14 @@ static uint16_t thumb_disasm_loadadr(struct thumb_disasm_t *ai, uint16_t inst) {
 	uint16_t src = (inst >> 11) & 0x01;
 	uint16_t offset = (inst & 0xff) << 2;
 	snprintf (ai->str, sizeof (ai->str),
-		"add %s, %s, #%d", tbl_regs[(inst >> 8) & 0x07], src ? "sp" : "pc",
+		"add %s, %s, %d", tbl_regs[(inst >> 8) & 0x07], src ? "sp" : "pc",
 			offset);
 	return 0;
 }
 
 static uint16_t thumb_disasm_swi(struct thumb_disasm_t *ai, uint16_t inst) {
 	uint16_t comment = inst & 0x00ff;
-	snprintf (ai->str, sizeof (ai->str), "swi #%d", comment);
+	snprintf (ai->str, sizeof (ai->str), "swi %d", comment);
 	return 0;
 }
 
@@ -189,14 +189,14 @@ static uint16_t thumb_disasm_nop(struct thumb_disasm_t *ai, uint16_t inst) {
 static uint16_t thumb_disasm_ldrpcrel(struct thumb_disasm_t *ai, uint16_t inst) {
 	uint16_t offset = (inst & 0xff) << 2;
 	snprintf (ai->str, sizeof (ai->str),
-		"ldr %s, [pc, #%u]", tbl_regs[(inst >> 8) & 0x07], offset);
+		"ldr %s, [pc, %u]", tbl_regs[(inst >> 8) & 0x07], offset);
 	return 0;
 }
 
 static uint16_t thumb_disasm_ldrsprel(struct thumb_disasm_t *ai, uint16_t inst) {
 	uint16_t offset = (inst & 0xff) << 2;
 	snprintf (ai->str, sizeof (ai->str),
-		"%s %s, [sp, #%u]", (inst & 0x0800)?"ldr":"str",
+		"%s %s, [sp, %u]", (inst & 0x0800)?"ldr":"str",
 		tbl_regs[(inst >> 8) & 0x07], offset);
 	return 0;
 }
@@ -205,13 +205,13 @@ static uint16_t thumb_disasm_addsprel(struct thumb_disasm_t *ai, uint16_t inst) 
 	uint16_t offset = (inst & 0x7f) << 2;
 	int sub = ((inst >> 7) & 0x01);
 	snprintf (ai->str, sizeof (ai->str),
-		"%s sp, sp, #%u", sub? "sub": "add", offset);
+		"%s sp, sp, %u", sub? "sub": "add", offset);
 	return 0;
 }
 
 static uint16_t thumb_disasm_ldrimm(struct thumb_disasm_t *ai, uint16_t inst) {
 	uint16_t offset = (inst & 0x07c0) >> 6;
-	snprintf (ai->str, sizeof (ai->str), "%s%s %s, [%s, #%u]",
+	snprintf (ai->str, sizeof (ai->str), "%s%s %s, [%s, %u]",
 			(inst & 0x0800)?"ldr":"str", (inst & 0x1000)?"b":"",
 			tbl_regs[inst & 0x07], tbl_regs[(inst >> 3) & 0x07],
 			(inst & 0x1000)?offset:(offset << 2));
@@ -220,7 +220,7 @@ static uint16_t thumb_disasm_ldrimm(struct thumb_disasm_t *ai, uint16_t inst) {
 
 static uint16_t thumb_disasm_ldrhimm(struct thumb_disasm_t *ai, uint16_t inst) {
 	uint16_t offset = (inst & 0x07c0) >> 5;
-	snprintf (ai->str, sizeof (ai->str), "%s %s, [%s, #%u]", (inst & 0x0800)?"ldrh":"strh",
+	snprintf (ai->str, sizeof (ai->str), "%s %s, [%s, %u]", (inst & 0x0800)?"ldrh":"strh",
 			tbl_regs[inst & 0x07], tbl_regs[(inst >> 3) & 0x07], offset);
 	return 0;
 }
@@ -243,7 +243,7 @@ static uint16_t thumb_disasm_ldrsreg(struct thumb_disasm_t *ai, uint16_t inst) {
 static uint16_t thumb_disasm_immop(struct thumb_disasm_t *ai, uint16_t inst) {
 	uint16_t op = (inst >> 11) & 0x03;
 	snprintf (ai->str, sizeof (ai->str),
-		"%s %s, #%u", tbl_immops_t[op], tbl_regs[(inst >> 8) & 0x07], inst & 0xff);
+		"%s %s, %u", tbl_immops_t[op], tbl_regs[(inst >> 8) & 0x07], inst & 0xff);
 	return 0;
 }
 
@@ -251,7 +251,7 @@ static uint16_t thumb_disasm_addsub(struct thumb_disasm_t *ai, uint16_t inst) {
 	char last [32];
 	uint16_t op = (inst >> 9) & 0x01;
 	uint16_t immediate = (inst >> 10) & 0x01;
-	if (immediate) snprintf (last, sizeof (last), "#%d", (inst >> 6) & 0x07);
+	if (immediate) snprintf (last, sizeof (last), "%d", (inst >> 6) & 0x07);
 	else strcpy (last, tbl_regs[(inst >> 6) & 0x07]);
 	snprintf (ai->str, sizeof (ai->str),
 		"%s %s, %s, %s", op ? "sub" : "add",
@@ -262,7 +262,7 @@ static uint16_t thumb_disasm_addsub(struct thumb_disasm_t *ai, uint16_t inst) {
 static uint16_t thumb_disasm_movshift(struct thumb_disasm_t *ai, uint16_t inst) {
 	uint16_t op = (inst >> 11) & 0x03;
 	snprintf (ai->str, sizeof (ai->str),
-		"%s %s, %s, #%u", tbl_shifts[op],
+		"%s %s, %s, %u", tbl_shifts[op],
 		tbl_regs[inst & 0x07], tbl_regs[(inst >> 3) & 0x07], (inst >> 6) & 0x1f);
 	return 0;
 }
@@ -377,9 +377,9 @@ static uint32_t thumb2_disasm_coprocmov1(struct thumb_disasm_t *ai, uint32_t ins
 	uint16_t opc1 = (inst >> 21) & 0x07;
 	uint16_t opc2 = (inst >> 5) & 0x07;
 	char last[32];
-	if (opc2) snprintf (last, sizeof (last), ", #%u", opc2); else *last = 0;
+	if (opc2) snprintf (last, sizeof (last), ", %u", opc2); else *last = 0;
 	snprintf (ai->str, sizeof (ai->str),
-		"%s%s  p%lu, #%u, %s, cr%lu, cr%lu%s", (inst & 0x00100000)?"mrc":"mcr",
+		"%s%s  p%lu, %u, %s, cr%lu, cr%lu%s", (inst & 0x00100000)?"mrc":"mcr",
 		(inst & 0x10000000)?"2":"", get_nibble(inst, 2), opc1,
 		tbl_regs[get_nibble(inst, 3)], get_nibble(inst, 4), get_nibble(inst, 0), last);
 	return 0;


### PR DESCRIPTION
- Initialize the program counter to get branch instructions properly disassembled.
- Avoid multiline instructions to get 2x more code in screen
- A bit faster scroll (100 -> 50 ms repeat)
- Select button to toggle between bytes and code
